### PR TITLE
Add a README with site link and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Physics Sandbox
+
+This repo contains simple physics simulations. Its website is http://www.physicsandbox.com/.
+
+### How to develop this locally
+
+To view the site, serve the root directory on localhost using a tool such as `python -m SimpleHTTPServer` or [http-server](https://github.com/indexzero/http-server).
+
+To compile the Haml and Sass files, you need Ruby and [Bundler](http://bundler.io/). First, `bundle install` the dependencies. Then you can run `bundle exec guard` to automatically recompile when changes are detected.
+
+The files in `assets/javascripts/` and `assets/images/` can be edited directly. They are not compiled from anything.


### PR DESCRIPTION
I’m not sure if the local development workflow really builds everything that needs to be built – I’m not sure how the creators build this. But this seems to work.
