### PR TITLE
Fix inaccurate ratio of mass to circle radius

### DIFF
--- a/assets/javascripts/pendulum.js
+++ b/assets/javascripts/pendulum.js
@@ -14,7 +14,8 @@ $('#set_variables_form').submit(function (e) {
 
 function drawCircle(myCircle, context) {
   context.beginPath();
-  context.arc(myCircle.x, myCircle.y, myCircle.mass, 0, 2 * Math.PI, false);
+  var radius = Math.sqrt(myCircle.mass) * 5;
+  context.arc(myCircle.x, myCircle.y, radius, 0, 2 * Math.PI, false);
   context.fillStyle = 'rgba(0,0,0,1)';
   context.fill();
 }


### PR DESCRIPTION
Assuming the black circles have uniform density and depth, then the radius varies with the _square root_ of the mass, not linearly with the mass. This is because the mass varies linearly with the _area_ of the circle.

I multiplied the result by 5 to get circles that were roughly the same size as before (though, necessarily, a smaller range of sizes).

Since I added a new line to calculate the radius on, you will have to update the Gist-slice line numbers in [`double-pendulum.haml`](https://github.com/micaeloliveira/physics-sandbox/blob/master/haml/double-pendulum.haml). I didn’t do the updates myself because [your live site](http://www.physicsandbox.com/projects/double-pendulum.html) seems to have line numbers for a different version of the code than the `master` branch (which this commit is based on). So you would eventually have to update the line numbers yourself anyway.
#### Before

Here is a circle with mass 1 and a circle with mass 50. Their difference in mass does not look like a factor of 50 – many more than 50 small circles could fit inside the big one.

![pendulum before, with circles of masses 1 and 50](https://cloud.githubusercontent.com/assets/79168/10715797/a71090c0-7af9-11e5-805c-6546921ff2e9.png)
#### After

Now the circle with mass 1 is truly 50 times smaller than the circle with mass 50.

![pendulum after, with circles of masses 1 and 50](https://cloud.githubusercontent.com/assets/79168/10715796/a7105bb4-7af9-11e5-9800-dbcfa14b06a3.png)
